### PR TITLE
Make library no_std compatible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,16 +67,17 @@
 //! output.push_str("world!");
 //! ```
 
+#![cfg_attr(not(test), no_std)]
 #![deny(missing_debug_implementations, missing_docs)]
+
+extern crate alloc;
 
 use cache_padded::CachePadded;
 
-use std::{
+use alloc::sync::Arc;
+use core::{
     cell::UnsafeCell,
-    sync::{
-        atomic::{AtomicU8, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicU8, Ordering},
 };
 
 /// A triple buffer, useful for nonblocking and thread-safe data sharing


### PR DESCRIPTION
This is a great mechanism for embedded software which needs to pass data between tasks, or between interrupts and idle loop code. Dependence on std currently prevents use on embedded targets, but I think it's possible to make this crate `no_std` without any negative consequence (see diff).

I've run the tests and everything passes- and there's no change to the code. Let me know what you think!