### PR TITLE
Replace cache-padded with crossbeam-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.46"
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-cache-padded = "1.1"
+crossbeam-utils = { version = "0.8.11", default-features = false }
 #
 # plotters now requires Rust 2021, and criterion uses plotters, so criterion is
 # now incompatible with our minimal supported Rust version. We only need tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 
 extern crate alloc;
 
-use cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 
 use alloc::sync::Arc;
 use core::{


### PR DESCRIPTION
We are planning on deprecating `cache-padded` in favor of `crossbeam-utils`, see smol-rs/cache-padded#10. This PR replaces `cache-padded` with `crossbeam-utils`.